### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "mongoose-unique-validator": "^2.0.1",
     "ng-drag-drop": "^5.0.0",
     "nodemon": "^1.17.5",
-    "npm": "^6.3.0",
     "passport": "^0.4.0",
     "passport-facebook": "^2.1.1",
     "passport-google-oauth": "^1.0.0",


### PR DESCRIPTION

Hello Abhishek-Matta!

It seems like you have npm as one of your (dev-) dependency in Trello.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
